### PR TITLE
Checking if Loki plug-in for Docker is present and installing/updating it accordingly

### DIFF
--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -21,30 +21,30 @@
     - /data/file-exporter
 
 # checking for docker/loki presence and installing/updating accordingly
-- name: Linux Server | Monitoring | verify if loki docker plug-in is installed
+- name: Linux Server | Monitoring | Check if Loki plug-in for Docker is present
   shell: if [ $(docker plugin ls | grep -o loki | wc -c) -eq 5 ]; then echo "present"; else echo "absent"; fi
   register: loki_state
   when: loki is defined
 
-- name: Linux Server | Monitoring | install loki docker plug-in
+- name: Linux Server | Monitoring | Install Loki plug-in for Docker
   shell: docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
   when: loki is defined and loki_state.stdout == 'absent'
 
-- name: check if loki docker plug-in is enabled
+- name: Linux Server | Monitoring | Check if Loki plug-in for Docker is enabled
   shell: if [ $(docker plugin ls | grep -o true) ]; then echo true; else echo false; fi
   register: loki_enabled
   when: loki is defined and loki_state.stdout == 'present'
 
-- name: disabling loki docker plug-in
+- name: Linux Server | Monitoring | Disable Loki plug-in for Docker
   shell: if [ $(docker plugin disable loki | grep -o loki | wc -c) -eq 5 ]; then echo "false"; else echo "true"; fi
   register: loki_enabled
   when: loki is defined and loki_state.stdout == 'present' and loki_enabled.stdout == 'true'
 
-- name: upgrading loki docker plug-in
+- name: Linux Server | Monitoring | Upgrade Loki plug-in for Docker
   shell: docker plugin upgrade loki grafana/loki-docker-driver:latest --grant-all-permissions
   when: loki is defined and loki_state.stdout == 'present' and (loki_enabled.stdout|d('false')) == 'false'
 
-- name: enabling loki docker plug-in
+- name: Linux Server | Monitoring | Enable Loki plug-in for Docker
   shell: docker plugin enable loki
   when: loki is defined and loki_state.stdout == 'present' and (loki_enabled.stdout|d('false')) == 'false'
 

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -20,11 +20,32 @@
   with_items:
     - /data/file-exporter
 
-# TODO : Check if the log plugin is installed, if is
-#docker plugin disable loki
-#docker plugin upgrade loki grafana/loki-docker-driver:master
-#docker plugin enable loki
-# and restart docker
+- name: verify if loki docker plug-in is installed
+  shell: if [ $(docker plugin ls | grep -o loki | wc -c) -eq 5 ]; then echo "present"; else echo "absent"; fi
+  register: loki_state
+  when: loki is defined
+
+- name: install loki docker plug-in
+  shell: docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
+  when: loki is defined and loki_state.stdout == 'absent'
+
+- name: check if loki docker plug-in is enabled
+  shell: if [ $(docker plugin ls | grep -o true) ]; then echo true; else echo false; fi
+  register: loki_enabled
+  when: loki is defined and loki_state.stdout == 'present'
+
+- name: disabling loki docker plug-in
+  shell: if [ $(docker plugin disable loki | grep -o loki | wc -c) -eq 5 ]; then echo "false"; else echo "true"; fi
+  register: loki_enabled
+  when: loki is defined and loki_state.stdout == 'present' and loki_enabled.stdout == 'true'
+
+- name: upgrading loki docker plug-in
+  shell: docker plugin upgrade loki grafana/loki-docker-driver:latest --grant-all-permissions
+  when: loki is defined and loki_state.stdout == 'present' and (loki_enabled.stdout|d('false')) == 'false'
+
+- name: enabling loki docker plug-in
+  shell: docker plugin enable loki
+  when: loki is defined and loki_state.stdout == 'present' and (loki_enabled.stdout|d('false')) == 'false'
 
 - name: Linux Server | Monitoring | Add docker plugin for remote logs
   command: docker plugin install  grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
@@ -51,7 +72,7 @@
       - "/file-exporter"
     state: started
     restart_policy: unless-stopped
-    memory: '32m'
+    memory: "32m"
     ports:
       - 9100:9100
 
@@ -69,7 +90,7 @@
     privileged: true
     state: started
     restart_policy: unless-stopped
-    memory: '96m'
+    memory: "96m"
     published_ports:
       - 9101:8080
 
@@ -100,7 +121,7 @@
     state: started
     restart: true
     restart_policy: unless-stopped
-    memory: '32m'
+    memory: "32m"
     published_ports:
       - 9080:9080
   when: loki is defined

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -20,12 +20,13 @@
   with_items:
     - /data/file-exporter
 
-- name: verify if loki docker plug-in is installed
+# checking for docker/loki presence and installing/updating accordingly
+- name: Linux Server | Monitoring | verify if loki docker plug-in is installed
   shell: if [ $(docker plugin ls | grep -o loki | wc -c) -eq 5 ]; then echo "present"; else echo "absent"; fi
   register: loki_state
   when: loki is defined
 
-- name: install loki docker plug-in
+- name: Linux Server | Monitoring | install loki docker plug-in
   shell: docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
   when: loki is defined and loki_state.stdout == 'absent'
 
@@ -46,12 +47,6 @@
 - name: enabling loki docker plug-in
   shell: docker plugin enable loki
   when: loki is defined and loki_state.stdout == 'present' and (loki_enabled.stdout|d('false')) == 'false'
-
-- name: Linux Server | Monitoring | Add docker plugin for remote logs
-  command: docker plugin install  grafana/loki-docker-driver:latest --alias loki --grant-all-permissions
-  ignore_errors: True
-  notify: docker configuration changed
-  when: loki is defined
 
 - name: Linux Server | Monitoring | Setup node exporter
   docker_container:


### PR DESCRIPTION
I know this might as well be suited to becoming a module for Ansible given the length of it, however, it does work and has been rigorously tested to exhaustion and performs the aforementioned tasks, which are as follows:

1. check if loki is installed in docker
> - if it is not, then install it
> - if it is, then upgrade it
2. when upgrading
> - first, disable the plugin
> - then perform the upgrade
> - finally, enable the plugin

All the commands and variables have fail-safe values and logic to make sure the tasks won't break and interrupt the execution.